### PR TITLE
Add support for multilingual gitbooks

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,14 @@ module.exports = {
                 config.label = "Edit This Page";
             }
 
-            rtEditLink = '<a href="' + config.base + '/' + page.path + '" class="btn fa fa-edit pull-left">&nbsp;&nbsp;' + config.label + '</a>';
+            // We need to calculate the path this way because multilingual
+            // books have wrong page.path
+            path = "/" + page.path;
+            if(this.options.originalInput !== undefined) {
+                path = page.rawPath.replace(this.options.originalInput, '');
+            }
+
+            rtEditLink = '<a href="' + config.base + path + '" class="btn fa fa-edit pull-left">&nbsp;&nbsp;' + config.label + '</a>';
 
             page.content = page.content.replace (
                 '<!-- Actions Right -->',

--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+var path = require('path');
+
 module.exports = {
     hooks: {
         // After html generation
@@ -12,14 +14,9 @@ module.exports = {
                 config.label = "Edit This Page";
             }
 
-            // We need to calculate the path this way because multilingual
-            // books have wrong page.path
-            path = "/" + page.path;
-            if(this.options.originalInput !== undefined) {
-                path = page.rawPath.replace(this.options.originalInput, '');
-            }
+            newPath = path.relative(this.options.originalInput, page.rawPath);
 
-            rtEditLink = '<a href="' + config.base + path + '" class="btn fa fa-edit pull-left">&nbsp;&nbsp;' + config.label + '</a>';
+            rtEditLink = '<a href="' + config.base + '/' + newPath + '" class="btn fa fa-edit pull-left">&nbsp;&nbsp;' + config.label + '</a>';
 
             page.content = page.content.replace (
                 '<!-- Actions Right -->',


### PR DESCRIPTION
In our multilingual book: https://github.com/DjangoGirls/ your plugin was generating wrong links, without the language prefix. I have created this change and as far as I checked it works properly with plain books and with the multilingual ones, but I am not sure how much "hacky" this solution is. I am not sure how gitbook handles languages.

Any comments are much appreciated. Thank you!
