### PR TITLE
plugin compatibility with the gitbook 2.0.1

### DIFF
--- a/book/plugin.js
+++ b/book/plugin.js
@@ -1,0 +1,6 @@
+require(["gitbook"], function(gitbook) {
+    gitbook.events.bind("page.change", function() {
+        // move the edit link to the header, after font-setting icon
+        $(document.getElementById("edit-link")).insertAfter("#font-settings-wrapper");
+    });
+});

--- a/index.js
+++ b/index.js
@@ -1,9 +1,13 @@
 var path = require('path');
 
 module.exports = {
+    book: {
+        assets: "./book",
+        js: ["plugin.js"]
+    },
     hooks: {
         // After html generation
-        "page:after": function(page) {
+        "page": function(page) {
             var config = this.options.pluginsConfig["edit-link"] || {};
 
             if (!config.base) {
@@ -14,14 +18,30 @@ module.exports = {
                 config.label = "Edit This Page";
             }
 
-            newPath = path.relative(this.options.originalInput, page.rawPath);
+            // add  slash at the end if not present
+            var base = config.base;
+            if(base.slice(-1) != "/") {
+                base = base + "/";
+            }
 
-            rtEditLink = '<a href="' + config.base + '/' + newPath + '" class="btn fa fa-edit pull-left">&nbsp;&nbsp;' + config.label + '</a>';
+            // relative path to the page
+            var newPath = path.relative(this.root, page.rawPath);
 
-            page.content = page.content.replace (
-                '<!-- Actions Right -->',
-                rtEditLink + '<!-- Actions Right -->'
-            )
+            // language, if configured
+            var lang = "";
+            if(this.context.config.language) {
+                lang = this.context.config.language + "/";
+            }
+
+            rtEditLink = '<a id="edit-link" href="' + base + lang + newPath + '" class="btn fa fa-edit pull-left">&nbsp;&nbsp;' + config.label + '</a>';
+
+            page.sections
+                .filter(function(section) {
+                    return section.type == 'normal';
+                })
+                .forEach(function(section) {
+                    section.content = rtEditLink + section.content;
+                });
 
             return page;
         }


### PR DESCRIPTION
Hi,
I made some changes in the hook and adapted it to the gitbook 2.0.1. This should solve the issue #3. It uses the `page` hook. The generated edit link is inserted directly into the page and later moved by `plugin.js` back to the menu bar. Gitbook still says, that `warn: hook 'page' used by plugin 'gitbook-plugin-edit-link' is deprecated, and will be remove in the coming versions`, but lots of plugins depend on this hook and I hope it will be available also in next releases. 

Could you please review and test the code on your setup? In the readme you don't mention any release/compatibility guidelines and I am not sure, how much backwards compatible my code is. 

I tested this PR in single and multilanguage book setups and it seems to work fine. But one never knows.

Best regards,
Tomas 
