### PR TITLE
Fixed error when there was no label set in config

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ module.exports = {
                 throw "ERROR: 'base' value required to generate 'Edit This Page' link. \nFor help, please refer to - https://github.com/rtCamp/gitbook-plugin-edit-link/blob/master/README.md#usage";
             }
 
-            var label = config.label[this.context.config.language] || config.label || "Edit This Page";
+            var label = (config.label && config.label[this.context.config.language]) || config.label || "Edit This Page";
 
             // add  slash at the end if not present
             var base = config.base;


### PR DESCRIPTION
Sorry about that. I had that fixed in my local code but somehow it did not get committed :-(

Also a question: Currently, if you do define a label for some but not all languages of your book, that could result in an error or strange output. Do you think we need to cover that? If so I'll add it to this PR.
