### PR TITLE
Replace a default branch with actual branch name

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,10 @@ Link target will be that page's source file on Github or Gitlab or any repo.
 
 **Github/Gitlab**: In string `...REPO/edit/BRANCH...`, you may replace `edit` with `tree` if you want source file to open in read-mode, rather than edit-mode directly on github/gitlab.
 
+##### Using the actual branch name
+
+It is possible to replace `BRANCH` with the actual Git branch name the Gitbook is built from. To achieve this you have to enclose a *default* branch name with brackets: in `"base": "https://github.com/USER/REPO/edit/[master]/path/to/book",` `[master]` will be replaced with the actual branch name if Git is installed and the GitBook is built within a repository. If that lookup fails the given default from `config.base` will be used (without the brackets).
+
 ### Step #2 - gitbook commands
 
 1. Run `gitbook install`. It will automatically install `edit-link` gitbook plugin for your book. This is needed only once.

--- a/index.js
+++ b/index.js
@@ -27,6 +27,24 @@ module.exports = {
                 base = base + "/";
             }
 
+            // replace placeholder with actual branch name
+            // if Git is installed
+
+            // Match a branch name in brackets
+            base = base.replace(/\[.+\]/, function gitBranch(defaultBranch) {
+              var sys = require('sys')
+              var spawn = require('child_process').spawnSync;
+              // Ask git for the current branch name
+              var run_cl = spawn("git", ["rev-parse", "--abbrev-ref", "HEAD"]);
+              // If it succeeds return it
+              if (run_cl.stdout != null) {
+                return run_cl.stdout.toString();
+              }
+              // else (=> Git is not installed) ignore the error message
+              // and return the default branch, stripped from the brackets
+              return defaultBranch.replace(/\[(.+)\]/, "$1");
+            });
+
             // relative path to the page
             var newPath = path.relative(this.root, page.rawPath);
 

--- a/index.js
+++ b/index.js
@@ -37,7 +37,7 @@ module.exports = {
               // Ask git for the current branch name
               var run_cl = spawn("git", ["rev-parse", "--abbrev-ref", "HEAD"]);
               // If it succeeds return it
-              if (run_cl.stdout != null) {
+              if ((run_cl.stdout != null) && (run_cl.stdout != "")) {
                 return run_cl.stdout.toString();
               }
               // else (=> Git is not installed) ignore the error message


### PR DESCRIPTION
This change makes it possible to create the link so it points towards lthe file at the current Git branch instead of the one hard-coded in the config file.

What happens: The plugin matches an expression in square brackets, and if it finds one:
- Ask Git for the current branch name
- If that succeeds replace the bracketed expression with teh branch name
- If it fails (e.g. Git is not installed) simply remove the brackets

If no brackets are present the behaviour is exactly as before.

Examples:

```
"base": "https://example.com/organization/repo/edit/[master]"
  a) current branch: staging
  => https://example.com/organization/repo/edit/staging/path/to/file
  b) Git is not installed
  => https://example.com/organization/repo/edit/master/path/to/file
```

Of course this should be documented ...
